### PR TITLE
feat: switch to minimal typescript setup to bring in typed methods

### DIFF
--- a/__tests__/app/index.js
+++ b/__tests__/app/index.js
@@ -1,5 +1,5 @@
 
-const app = require('../../app/');
+const app = require('../../app/').default;
 
 describe('fastTypeCheck', () => {
     describe('Method tests', () => {

--- a/__tests__/lib/fastTypeCheck.js
+++ b/__tests__/lib/fastTypeCheck.js
@@ -1,5 +1,5 @@
 
-const tc = require('../../lib/fastTypeCheck');
+const tc = require('../../lib/fastTypeCheck.js').default;
 
 describe('fastTypeCheckLib', () => {
     describe('Method tests', () => {

--- a/lib/fastTypeCheck.d.ts
+++ b/lib/fastTypeCheck.d.ts
@@ -1,0 +1,56 @@
+/**
+ * https://github.com/5orenso
+ *
+ * Copyright (c) 2019-2020 Øistein Sørensen
+ * Licensed under the MIT license.
+ */
+type PathOf<T> = T extends object ? {
+    [K in keyof T]: K extends string ? (T[K] extends object ? `${K}` | `${K}.${PathOf<T[K]>}` : `${K}`) : never;
+}[keyof T] : never;
+type ValueAtPath<T, P extends string> = P extends `${infer K}.${infer Rest}` ? K extends keyof T ? ValueAtPath<T[K], Rest> : never : P extends keyof T ? T[P] : never;
+export default class FastTypeCheck {
+    static getType(element: unknown): string;
+    static isError(element: unknown): boolean;
+    static isArray(element: unknown): element is unknown[];
+    static isObject(element: unknown): element is Record<string, unknown>;
+    static isEmptyObject(element: unknown): boolean;
+    static isString(element: unknown): element is string;
+    static isDate(element: unknown): element is Date;
+    static isNumber(element: unknown): element is number;
+    static isFunction(element: unknown): element is (...args: unknown[]) => unknown;
+    static isRegexp(element: unknown): element is RegExp;
+    static isBoolean(element: unknown): element is boolean;
+    static isNull(element: unknown): element is null;
+    static isUndefined(element: unknown): element is undefined;
+    static isDefined(element: unknown): element is Exclude<unknown, undefined>;
+    static isMongoObject(element: unknown): boolean;
+    static isArrayOfObjects(element: unknown): boolean;
+    static isArrayOfArrays(element: unknown): boolean;
+    static isArrayOfStrings(element: unknown): boolean;
+    static isArrayOfNumbers(element: unknown): boolean;
+    static isArrayOfMongoObjects(element: unknown): boolean;
+    static isEqual(a: unknown, b: unknown): boolean;
+    static isEqualArrays<T>(array1: T[], array2: T[]): boolean;
+    static isEqualObjects(object1: Record<string, unknown>, object2: Record<string, unknown>): boolean;
+    static isInArray<T>(finalArray: T[], objectElement: T): boolean;
+    static isValidEmail(email: unknown): boolean;
+    static ensureNumber(input: unknown, useUndefined?: boolean): number | undefined;
+    static ensureString(input: unknown, useUndefined?: boolean): string | undefined;
+    static ensureArray(input: unknown, useUndefined?: boolean): unknown[] | undefined;
+    static ensureObject(input: unknown, useUndefined?: boolean): Record<string, unknown> | undefined;
+    static ensureUniqArray<T>(input: T[]): T[];
+    static ensureDate(input: unknown): Date | undefined;
+    static ensureBoolean(input: unknown): boolean | undefined;
+    static ensureValidEmail($email: unknown): string | undefined;
+    static parseObject($obj: Record<string, unknown>, ...$args: unknown[]): unknown | null;
+    static checkNested($obj: Record<string, unknown>, ...args: string[]): boolean;
+    static getNestedValue<T>(obj: T, path: PathOf<T>): unknown | null;
+    static setNestedValue<T extends Record<string, unknown>, P extends PathOf<T>>(obj: T, path: P, value: ValueAtPath<T, P>): T;
+    static cleanObject($obj: Record<string, unknown>): Record<string, unknown>;
+    static dump(input: unknown): string;
+    static lc($str: unknown): string;
+    static uc($str: unknown): string;
+    static ucFirst($str: unknown, skipRest?: boolean): string;
+    static ucFirstWord($str: unknown): string;
+}
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "fast-type-check",
-  "version": "1.3.3",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fast-type-check",
-      "version": "1.3.3",
+      "version": "1.3.6",
       "bin": {
         "fast-type-check": "bin/fast-type-check"
       },
       "devDependencies": {
+        "@types/node": "^22.10.1",
         "babel-plugin-transform-regenerator": "^6.26.0",
         "babel-plugin-transform-runtime": "^6.23.0",
         "eslint": "^8.11.0",
@@ -1177,6 +1178,16 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "1.0.1",
@@ -10666,6 +10677,13 @@
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -12113,6 +12131,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -19688,6 +19715,12 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "node": ">=8.11.0"
   },
   "scripts": {
+    "compile": "tsc",
     "lint": "eslint ./lib/**/*.js ./app/**/*.js",
     "test": "jest --coverage",
     "test:simple": "jest",
@@ -31,6 +32,7 @@
     "fast-type-check": "./bin/fast-type-check"
   },
   "devDependencies": {
+    "@types/node": "^22.10.1",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "eslint": "^8.11.0",
@@ -42,7 +44,6 @@
     "jsdoc-to-markdown": "^5.0.3"
   },
   "keywords": [],
-  "dependencies": {},
   "jest": {
     "verbose": true,
     "globals": {

--- a/src/fastTypeCheck.ts
+++ b/src/fastTypeCheck.ts
@@ -1,120 +1,152 @@
-"use strict";
 /**
  * https://github.com/5orenso
  *
  * Copyright (c) 2019-2020 Øistein Sørensen
  * Licensed under the MIT license.
  */
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
+
+
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
-const assert_1 = __importDefault(require("assert"));
+import  assert from 'assert';
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
-const util_1 = require("util");
+import { inspect } from 'util';
+
+type PathOf<T> = T extends object
+    ? { [K in keyof T]: K extends string ? (T[K] extends object ? `${K}` | `${K}.${PathOf<T[K]>}` : `${K}`) : never }[keyof T]
+    : never;
+
+type ValueAtPath<T, P extends string> = P extends `${infer K}.${infer Rest}`
+    ? K extends keyof T
+    ? ValueAtPath<T[K], Rest>
+    : never
+    : P extends keyof T
+    ? T[P]
+    : never;
+
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
-class FastTypeCheck {
-    static getType(element) {
+export default class FastTypeCheck {
+    static getType(element: unknown): string {
         return Object.prototype.toString.call(element);
     }
-    static isError(element) {
+
+    static isError(element: unknown): boolean {
         return FastTypeCheck.getType(element) === '[object Error]';
     }
-    static isArray(element) {
+
+    static isArray(element: unknown): element is unknown[] {
         return FastTypeCheck.getType(element) === '[object Array]';
     }
-    static isObject(element) {
+
+    static isObject(element: unknown): element is Record<string, unknown> {
         return FastTypeCheck.getType(element) === '[object Object]';
     }
-    static isEmptyObject(element) {
+
+    static isEmptyObject(element: unknown): boolean {
         if (FastTypeCheck.isObject(element)) {
             const keys = Object.keys(element);
             return keys.length === 0;
         }
         return false;
     }
-    static isString(element) {
+
+    static isString(element: unknown): element is string {
         return FastTypeCheck.getType(element) === '[object String]';
     }
-    static isDate(element) {
+
+    static isDate(element: unknown): element is Date {
         return FastTypeCheck.getType(element) === '[object Date]';
     }
-    static isNumber(element) {
+
+    static isNumber(element: unknown): element is number {
         return FastTypeCheck.getType(element) === '[object Number]' && !Number.isNaN(element);
     }
-    static isFunction(element) {
+
+    static isFunction(element: unknown): element is (...args: unknown[]) => unknown {
         return FastTypeCheck.getType(element) === '[object Function]';
     }
-    static isRegexp(element) {
+
+    static isRegexp(element: unknown): element is RegExp {
         return FastTypeCheck.getType(element) === '[object RegExp]';
     }
-    static isBoolean(element) {
+
+    static isBoolean(element: unknown): element is boolean {
         return FastTypeCheck.getType(element) === '[object Boolean]';
     }
-    static isNull(element) {
+
+    static isNull(element: unknown): element is null {
         return FastTypeCheck.getType(element) === '[object Null]';
     }
-    static isUndefined(element) {
+
+    static isUndefined(element: unknown): element is undefined {
         return FastTypeCheck.getType(element) === '[object Undefined]';
     }
-    static isDefined(element) {
+
+    static isDefined(element: unknown): element is Exclude<unknown, undefined> {
         return !FastTypeCheck.isUndefined(element);
     }
-    static isMongoObject(element) {
+
+    static isMongoObject(element: unknown): boolean {
         if (FastTypeCheck.isObject(element)) {
-            return Object.prototype.hasOwnProperty.call(element, '_id') && /[a-z0-9]+/i.test(element._id);
+            return Object.prototype.hasOwnProperty.call(element, '_id') && /[a-z0-9]+/i.test(element._id as string);
         }
         return false;
     }
-    static isArrayOfObjects(element) {
+
+    static isArrayOfObjects(element: unknown): boolean {
         return FastTypeCheck.isArray(element) && element.length > 0 && element.every(item => FastTypeCheck.isObject(item));
     }
-    static isArrayOfArrays(element) {
+
+    static isArrayOfArrays(element: unknown): boolean {
         return FastTypeCheck.isArray(element) && element.length > 0 && element.every(item => FastTypeCheck.isArray(item));
     }
-    static isArrayOfStrings(element) {
+
+    static isArrayOfStrings(element: unknown): boolean {
         return FastTypeCheck.isArray(element) && element.length > 0 && element.every(item => FastTypeCheck.isString(item));
     }
-    static isArrayOfNumbers(element) {
+
+    static isArrayOfNumbers(element: unknown): boolean {
         return FastTypeCheck.isArray(element) && element.length > 0 && element.every(item => FastTypeCheck.isNumber(item));
     }
-    static isArrayOfMongoObjects(element) {
+
+    static isArrayOfMongoObjects(element: unknown): boolean {
         return FastTypeCheck.isArray(element) && element.length > 0 && element.every(item => FastTypeCheck.isMongoObject(item));
     }
-    static isEqual(a, b) {
+
+    static isEqual(a: unknown, b: unknown): boolean {
         return Object.is(a, b);
     }
-    static isEqualArrays(array1, array2) {
+
+    static isEqualArrays<T>(array1: T[], array2: T[]): boolean {
         return array1.length === array2.length && array1.every((el, i) => FastTypeCheck.isEqual(el, array2[i]));
     }
-    static isEqualObjects(object1, object2) {
+
+    static isEqualObjects(object1: Record<string, unknown>, object2: Record<string, unknown>): boolean {
         try {
-            assert_1.default.deepEqual(object1, object2);
+            assert.deepEqual(object1, object2);
             return true;
-        }
-        catch (_a) {
+        } catch {
             return false;
         }
     }
-    static isInArray(finalArray, objectElement) {
+
+    static isInArray<T>(finalArray: T[], objectElement: T): boolean {
         let idx = -1;
         if (FastTypeCheck.isObject(objectElement)) {
-            idx = finalArray.findIndex(el => FastTypeCheck.isEqualObjects(el, objectElement));
-        }
-        else if (FastTypeCheck.isArray(objectElement)) {
-            idx = finalArray.findIndex(el => FastTypeCheck.isEqualArrays(el, objectElement));
-        }
-        else if (FastTypeCheck.isNumber(objectElement) || FastTypeCheck.isString(objectElement) || FastTypeCheck.isBoolean(objectElement)) {
+            idx = finalArray.findIndex(el => FastTypeCheck.isEqualObjects(el as Record<string, unknown>, objectElement));
+        } else if (FastTypeCheck.isArray(objectElement)) {
+            idx = finalArray.findIndex(el => FastTypeCheck.isEqualArrays(el as unknown[], objectElement));
+        } else if (FastTypeCheck.isNumber(objectElement) || FastTypeCheck.isString(objectElement) || FastTypeCheck.isBoolean(objectElement)) {
             idx = finalArray.findIndex(el => FastTypeCheck.isEqual(el, objectElement));
         }
         return idx >= 0;
     }
-    static isValidEmail(email) {
+
+    static isValidEmail(email: unknown): boolean {
         const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(String(email).toLowerCase());
     }
-    static ensureNumber(input, useUndefined = false) {
+
+    static ensureNumber(input: unknown, useUndefined = false): number | undefined {
         if (FastTypeCheck.isNumber(input)) {
             return input;
         }
@@ -128,14 +160,15 @@ class FastTypeCheck {
         if (FastTypeCheck.isString(input)) {
             number = input.replace(/,/g, '.').replace(/\s+/g, '');
         }
-        number = Number.parseFloat(number);
+        number = Number.parseFloat(number as string);
         if (FastTypeCheck.isNumber(number)) {
             return number;
         }
-        const integer = Number.parseInt(input, 10);
+        const integer = Number.parseInt(input as string, 10);
         return FastTypeCheck.isNumber(integer) ? integer : useUndefined ? undefined : 0;
     }
-    static ensureString(input, useUndefined = false) {
+
+    static ensureString(input: unknown, useUndefined = false): string | undefined {
         if (FastTypeCheck.isString(input)) {
             return input;
         }
@@ -144,7 +177,8 @@ class FastTypeCheck {
         }
         return useUndefined ? undefined : '';
     }
-    static ensureArray(input, useUndefined = false) {
+
+    static ensureArray(input: unknown, useUndefined = false): unknown[] | undefined {
         if (FastTypeCheck.isArray(input)) {
             return input;
         }
@@ -153,7 +187,8 @@ class FastTypeCheck {
         }
         return useUndefined ? undefined : [];
     }
-    static ensureObject(input, useUndefined = false) {
+
+    static ensureObject(input: unknown, useUndefined = false): Record<string, unknown> | undefined {
         if (FastTypeCheck.isObject(input)) {
             return input;
         }
@@ -165,9 +200,10 @@ class FastTypeCheck {
         }
         return useUndefined ? undefined : {};
     }
-    static ensureUniqArray(input) {
+
+    static ensureUniqArray<T>(input: T[]): T[] {
         if (Array.isArray(input)) {
-            const finalArray = [];
+            const finalArray: T[] = [];
             for (const el of input) {
                 if (!FastTypeCheck.isInArray(finalArray, el)) {
                     finalArray.push(el);
@@ -177,7 +213,8 @@ class FastTypeCheck {
         }
         return input;
     }
-    static ensureDate(input) {
+
+    static ensureDate(input: unknown): Date | undefined {
         if (FastTypeCheck.isDate(input)) {
             return input;
         }
@@ -189,7 +226,8 @@ class FastTypeCheck {
         }
         return undefined;
     }
-    static ensureBoolean(input) {
+
+    static ensureBoolean(input: unknown): boolean | undefined {
         if (FastTypeCheck.isBoolean(input)) {
             return input;
         }
@@ -201,92 +239,102 @@ class FastTypeCheck {
         }
         return undefined;
     }
-    static ensureValidEmail($email) {
-        var _a;
-        const email = (_a = FastTypeCheck.ensureString($email)) === null || _a === void 0 ? void 0 : _a.trim().toLowerCase();
+
+    static ensureValidEmail($email: unknown): string | undefined {
+        const email = FastTypeCheck.ensureString($email)?.trim().toLowerCase();
         return email && FastTypeCheck.isValidEmail(email) ? email : undefined;
     }
-    static parseObject($obj, ...$args) {
-        const args = Array.isArray($args[0]) ? $args[0] : $args;
+
+    static parseObject($obj: Record<string, unknown>, ...$args: unknown[]): unknown | null {
+        const args: string[] = Array.isArray($args[0]) ? $args[0] as string[] : $args as string[];
         let obj = $obj;
         for (const key of args) {
             if (!obj || !(key in obj)) {
                 return null;
             }
-            obj = obj[key];
+            obj = obj[key] as Record<string, unknown>;
         }
         return typeof obj === 'object' ? obj : null;
     }
-    static checkNested($obj, ...args) {
+
+    static checkNested($obj: Record<string, unknown>, ...args: string[]): boolean {
         let obj = $obj;
         for (const key of args) {
             if (!obj || !(key in obj)) {
                 return false;
             }
-            obj = obj[key];
+            obj = obj[key] as Record<string, unknown>;
         }
         return true;
     }
-    static getNestedValue(obj, path) {
+
+    static getNestedValue<T>(obj: T, path: PathOf<T>): unknown | null {
         if (!FastTypeCheck.isObject(obj) || !FastTypeCheck.isString(path)) {
             return null;
         }
+
         const parts = path.split('.');
-        let el = obj;
+        let el: unknown = obj;
         for (const part of parts) {
-            el = el[part];
+            el = (el as Record<string, unknown>)[part];
             if (el === undefined) {
                 return null;
             }
         }
         return el;
     }
-    static setNestedValue(obj, path, value) {
-        const parts = path.split('.');
-        let current = obj;
+
+    static setNestedValue<T extends Record<string, unknown>, P extends PathOf<T>>(
+        obj: T,
+        path: P,
+        value: ValueAtPath<T, P>
+    ): T {
+        const parts = path.split('.') as Array<keyof unknown>;
+        let current = obj as Record<string, unknown>;
+
         for (let i = 0; i < parts.length; i++) {
             const part = parts[i];
             if (i === parts.length - 1) {
                 current[part] = value;
-            }
-            else {
-                current = current[part];
+            } else {
+                current = current[part] as Record<string, unknown>;
             }
         }
+
         return obj;
     }
-    static cleanObject($obj) {
-        const obj = Object.assign({}, $obj);
+
+    static cleanObject($obj: Record<string, unknown>): Record<string, unknown> {
+        const obj = { ...$obj };
         for (const idx of Object.keys(obj)) {
             if (Object.prototype.hasOwnProperty.call(obj, idx)) {
                 if (obj[idx] === undefined || obj[idx] === false || obj[idx] === null || Number.isNaN(obj[idx]) || FastTypeCheck.isEmptyObject(obj[idx])) {
                     delete obj[idx];
                 }
             }
-        }
-        ;
+        };
         return obj;
     }
-    static dump(input) {
-        return (0, util_1.inspect)(input, { showHidden: false, depth: null });
+
+    static dump(input: unknown): string {
+        return inspect(input, { showHidden: false, depth: null });
     }
-    static lc($str) {
-        var _a, _b;
-        return (_b = (_a = FastTypeCheck.ensureString($str)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) !== null && _b !== void 0 ? _b : '';
+
+    static lc($str: unknown): string {
+        return FastTypeCheck.ensureString($str)?.toLowerCase() ?? '';
     }
-    static uc($str) {
-        var _a, _b;
-        return (_b = (_a = FastTypeCheck.ensureString($str)) === null || _a === void 0 ? void 0 : _a.toUpperCase()) !== null && _b !== void 0 ? _b : '';
+
+    static uc($str: unknown): string {
+        return FastTypeCheck.ensureString($str)?.toUpperCase() ?? '';
     }
-    static ucFirst($str, skipRest = false) {
-        var _a;
-        const str = (_a = FastTypeCheck.ensureString($str)) === null || _a === void 0 ? void 0 : _a.trim();
+
+    static ucFirst($str: unknown, skipRest = false): string {
+        const str = FastTypeCheck.ensureString($str)?.trim();
         return str ? str.charAt(0).toUpperCase() + (skipRest ? '' : str.slice(1)) : '';
     }
-    static ucFirstWord($str) {
-        var _a;
-        const str = (_a = FastTypeCheck.ensureString($str)) === null || _a === void 0 ? void 0 : _a.trim();
+
+    static ucFirstWord($str: unknown): string {
+        const str = FastTypeCheck.ensureString($str)?.trim();
         return str ? str.split(' ').map(val => val.charAt(0).toUpperCase() + val.slice(1)).join(' ') : '';
     }
 }
-exports.default = FastTypeCheck;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Why?
- It now brings full backed-in typing inference for all the methods.
- Projects/libs dependent on this lib will benefit from it.

Note:
- I couldn't get to run the linter without resetting the linting logic all together.
- It'll need some version bumping and re-compiling (`npm run compile`) before eventually publishing.